### PR TITLE
Fix crash editing input value for a virtual signal

### DIFF
--- a/script/gui.lua
+++ b/script/gui.lua
@@ -233,14 +233,14 @@ local function change_signal_count(ltnc, e)
   end
 
   local value = signal.count
-  local stack_size = 1 --Fluid doesn't have stacks
-  dlog(signal.signal.type .. " " .. stack_size)
+  dlog(signal.signal.type)
   local slider_type
   ltnc.signal_value_text.enabled = true
   ltnc.signal_value_text.text = tostring(value)
   ltnc.signal_value_text.focus()
   ltnc.signal_value_confirm.enabled = false
   if signal.signal.type == "item" or signal.signal.type == "fluid" then
+    local stack_size
     if signal.signal.type == "item" then
       slider_type = "slider-max-items"
       stack_size = game.item_prototypes[signal.signal.name].stack_size
@@ -250,6 +250,7 @@ local function change_signal_count(ltnc, e)
       end
     elseif signal.signal.type == "fluid" then
       slider_type = "slider-max-fluid"
+      stack_size = 1 --Fluid doesn't have stacks
       ltnc.signal_value_stack.enabled = false
     end
     local max_slider = stack_size * settings.get_player_settings(e.player_index)[slider_type].value
@@ -264,6 +265,7 @@ local function change_signal_count(ltnc, e)
     -- Not Item or Fluid
     ltnc.signal_value_stack.enabled = false
     ltnc.signal_value_slider.enabled = false
+    ltnc.stack_size = 1 -- Other signals don't have stacks
   end
 end -- change_signal_count()
 


### PR DESCRIPTION
Problem:
When editing input value for a virtual signal, on_gui_text_changed tries to compute the stack size by accessing ltnc.stack_size member, which is nil and crash occurs.
This is because on_gui_text_changed function only sets the ltnc.stack_size for items and fluids, but not virtual signal.
reported: https://mods.factorio.com/mod/LTN_Combinator_Modernized/discussion/60bc34974289beda8d7c24e6

Solution:
Set the ltnc.stack_size to 1 for virtual signals in a similar manner that stack_size is set to 1 for fluids that also don't stacks. This allows for a manual input of virtual signal without crash.

Testing:
Tested gui with manually inputing positive and negative values for an item, fluid and virtual signals. Stack editing works for items. For non-items it remains disabled and stack value remains set to signal value. The slider remains disabled for virtual signals.