### PR TITLE
Adds a basic option to have newly placed combinators disabled

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -2,6 +2,7 @@ MOD_STRING  = "LTN Combinator"
 
 print, dlog = require "script.logger" ()
 local config = require("config")
+local on_built = require("script.on_built")
 require("script.util")
 require("script.gui")
 require("script.remote")
@@ -36,3 +37,9 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, function(e)
 		config.ltn_signals["ltn-network-id"].default = default_networkid
 	end
 end)
+
+local ev = defines.events
+script.on_event(
+	{ev.on_built_entity, ev.on_robot_built_entity, ev.script_raised_built, ev.script_raised_revive},
+	on_built.check_built_entity
+)

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -43,6 +43,7 @@ ltnc-upgradable=Upgradable from Constant Combinator
 slider-max-items=Request slider maximum stacks (items)
 use-stacks=Request by stacks  
 slider-max-fluid=Request slider maximum (fluid)
+disable-built-combinators=Disable newly built LTN combinators
 
 [mod-setting-description]
 suppress-custom-gui=If an update to LogisticTranNetwork creates conflicts with LTN Combinators, enable this option to use the vanilla GUI for constant combinators.
@@ -53,6 +54,7 @@ ltnc-upgradable=Considered an upgraded tier of the constant combinator.  A defau
 slider-max-items=The maximum number of items (stacks) you can request using the slider.  You may still enter larger values directly.\n\n[color=blue]Default:[/color] [color=green]256[/color]
 use-stacks=If checked, requests for items will be entered as stacks instead of individual count.\n\n[color=blue]Default:[/color] [color=green]True[/color]
 slider-max-fluid=The maximum units of fluid that can be requested using the slider.  You may still enter larger values directly.\n\n[color=blue]Default:[/color] [color=green]500k[/color]
+disable-built-combinators=
 [string-mod-setting]
 provide-type-only-item-count=Normal thresholds only
 provide-type-both-item-stack=Normal and Stack thresholds

--- a/script/on_built.lua
+++ b/script/on_built.lua
@@ -1,0 +1,16 @@
+local me = {}
+function me.check_built_entity(event)
+	if settings.global["disable-built-combinators"].value then
+		local built_entity = event.created_entity or event.entity
+		if not built_entity then
+			return
+		end
+		if built_entity.type == "constant-combinator" and built_entity.name == "ltn-combinator" then
+			local control_behavior = built_entity.get_control_behavior()
+			if control_behavior and control_behavior.enabled then
+				control_behavior.enabled = false
+			end
+		end
+	end
+end
+return me

--- a/settings.lua
+++ b/settings.lua
@@ -8,6 +8,13 @@ data:extend({
     },
     {
         type = "bool-setting",
+        name = "disable-built-combinators",
+        order = "mb",
+        setting_type = "runtime-global",
+        default_value = false
+    },
+    {
+        type = "bool-setting",
         name = "show-all-panels",
         setting_type = "runtime-per-user",
         order = "ua",


### PR DESCRIPTION
Related to https://github.com/kryojenik/LTN_Combinator_Modernized/issues/7

While reading the issue it seemed to my like this is the typical issue where the perfect solution would be rather complex but is not prioritized enough to implement it as such.
 
Based on the saying  "A bird in the hand is worth two in the bush" this is a very very simple approach to this problem.
It will work but it lacks elegance and flexibility.

Please test in detail as I did only a one-shot testing.