### PR TITLE
Add a hotkey to open ltnc remotely

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -3,3 +3,12 @@ require ("prototypes.entity")
 require ("prototypes.event")
 require ("prototypes.styles")
 flib = nil
+
+data:extend({
+  -- custom inputs
+  {
+    type = "custom-input",
+    name = "ltnc-hotkey",
+    key_sequence = ""
+  }
+})

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -1,6 +1,9 @@
 [entity-name]
 ltn-combinator=LTN Combinator
 
+[controls]
+ltnc-hotkey=Open LTN Combinator remotely
+
 [entity-description]
 ltn-combinator=Outputs constant signals to be used by a Logistic Train Stop
 

--- a/script/remote.lua
+++ b/script/remote.lua
@@ -87,14 +87,14 @@ remote.add_interface("ltn-combinator", {
     if game.players[event.player_index] then
       entity = game.players[event.player_index].selected
     end
-
-    if entity == nil or entity.valid ~= true then return end
+    
+    if entity == nil or entity.valid ~= true or entity.name ~= "ltn-combinator" then return end
     remote.call("ltn-combinator", "open_ltn_combinator", event.player_index, entity, true)
   end
 
   local function ltnc_remote_close(event)
     remote.call("ltn-combinator", "close_ltn_combinator", event.player_index)
   end
-
+  script.on_event("ltnc-hotkey", ltnc_remote_open)
   commands.add_command("ltncopen", "Use /ltncopen while hovering an entity to open a near ltn combinator", ltnc_remote_open)
   commands.add_command("ltncclose", "Use /ltncclose to close the opened ltn combinator", ltnc_remote_close)


### PR DESCRIPTION
Howdy, this is just a small change I made to open the combinator remotely at any distance without needing to use the console or LTN-Manager

I've been using this for the last few weeks and set it to use a mouse click - but I left it `not-set` by default here :)