### PR TITLE
Qol-stack-treshold

### DIFF
--- a/script/ltn_combinator.lua
+++ b/script/ltn_combinator.lua
@@ -1542,13 +1542,13 @@ local function on_built(e)
       local requester_stack_threshold = get_ltn_signal_from_control(ctl, "ltn-requester-stack-threshold")
 
       if provider_stack_threshold.is_default then
-          set_ltn_signal_by_control(ctl, max_train_length.value * 40, "ltn-provider-stack-threshold")
+          set_ltn_signal_by_control(ctl, (max_train_length.value - 1) * 40, "ltn-provider-stack-threshold")
       end
       if requester_stack_threshold.is_default then
-          set_ltn_signal_by_control(ctl, max_train_length.value * 40, "ltn-requester-stack-threshold")
+          set_ltn_signal_by_control(ctl, (max_train_length.value - 1) * 40, "ltn-requester-stack-threshold")
       end
   end
-  
+
 end -- on_built()
 
 --- @param e EventData.on_player_setup_blueprint

--- a/script/ltn_combinator.lua
+++ b/script/ltn_combinator.lua
@@ -1533,6 +1533,22 @@ local function on_built(e)
     toggle_service_by_ctl(ctl, "provider", false)
     toggle_service_by_ctl(ctl, "requester", false)
   end
+
+  -- If there is no signal for stack thresholds, set them based on train length
+  local max_train_length = get_ltn_signal_from_control(ctl, "ltn-max-train-length")
+
+  if not max_train_length.is_default then
+      local provider_stack_threshold = get_ltn_signal_from_control(ctl, "ltn-provider-stack-threshold")
+      local requester_stack_threshold = get_ltn_signal_from_control(ctl, "ltn-requester-stack-threshold")
+
+      if provider_stack_threshold.is_default then
+          set_ltn_signal_by_control(ctl, max_train_length.value * 40, "ltn-provider-stack-threshold")
+      end
+      if requester_stack_threshold.is_default then
+          set_ltn_signal_by_control(ctl, max_train_length.value * 40, "ltn-requester-stack-threshold")
+      end
+  end
+  
 end -- on_built()
 
 --- @param e EventData.on_player_setup_blueprint


### PR DESCRIPTION
Love the mod, thanks for your work!

In my use case I had LTN Station BPs that was converted to use LTN Combinator which had min-max train sizes but no stack thresholds set. This feature checks if max train size is not default and sets stack tresholds based on it (40 x (max train size - 1)) if they are default (which is 0)

I have tested it ingame, seems to be working as intended and not causing any errors. Thank you for your consideration